### PR TITLE
Fix deterministic attribute hashing

### DIFF
--- a/browser_use/dom/history_tree_processor/service.py
+++ b/browser_use/dom/history_tree_processor/service.py
@@ -92,9 +92,14 @@ class HistoryTreeProcessor:
 		return hashlib.sha256(parent_branch_path_string.encode()).hexdigest()
 
 	@staticmethod
-	def _attributes_hash(attributes: dict[str, str]) -> str:
-		attributes_string = ''.join(f'{key}={value}' for key, value in attributes.items())
-		return hashlib.sha256(attributes_string.encode()).hexdigest()
+        def _attributes_hash(attributes: dict[str, str]) -> str:
+                """Return a stable hash for a dictionary of attributes."""
+                # Sort attributes to ensure deterministic hashes regardless of
+                # insertion order of the dictionary.
+                attributes_string = ''.join(
+                        f'{key}={value}' for key, value in sorted(attributes.items())
+                )
+                return hashlib.sha256(attributes_string.encode()).hexdigest()
 
 	@staticmethod
 	def _xpath_hash(xpath: str) -> str:

--- a/tests/test_history_tree_processor.py
+++ b/tests/test_history_tree_processor.py
@@ -1,0 +1,10 @@
+import pytest
+from browser_use.dom.history_tree_processor.service import HistoryTreeProcessor
+
+
+def test_attributes_hash_deterministic_order():
+    attrs1 = {"id": "value", "class": "foo"}
+    attrs2 = {"class": "foo", "id": "value"}
+    hash1 = HistoryTreeProcessor._attributes_hash(attrs1)
+    hash2 = HistoryTreeProcessor._attributes_hash(attrs2)
+    assert hash1 == hash2


### PR DESCRIPTION
## Summary
- sort attributes before hashing in `HistoryTreeProcessor._attributes_hash`
- add regression test covering hashing order

## Testing
- `ruff check .` *(fails: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`)*
- `pytest tests/test_history_tree_processor.py -q` *(fails: pytest not installed)*